### PR TITLE
std::round is not defined in some platforms

### DIFF
--- a/include/supercluster.hpp
+++ b/include/supercluster.hpp
@@ -127,8 +127,8 @@ public:
         auto visitor = [&, this](const auto &id) {
             auto const &c = zoom.clusters[id];
 
-            TilePoint point(std::round(this->options.extent * (c.pos.x * z2 - x)),
-                            std::round(this->options.extent * (c.pos.y * z2 - y)));
+            TilePoint point(::round(this->options.extent * (c.pos.x * z2 - x)),
+                            ::round(this->options.extent * (c.pos.y * z2 - y)));
             TileFeature feature{ point };
 
             if (c.num_points == 1) {


### PR DESCRIPTION
Use the C version.

Found when building Mapbox GL on the Qt CI.