### PR TITLE
Adds cast to avoid loss of precision compile error. 

### DIFF
--- a/include/supercluster.hpp
+++ b/include/supercluster.hpp
@@ -253,7 +253,10 @@ private:
                 auto num_points = p.num_points;
                 point<double> weight = p.pos * double(num_points);
 
-                std::uint32_t id = (i << 5) + (zoom + 1);
+                assert((i & ((1 << 27) - 1)) == i); // point_index encoded in the upper 27 bits
+                assert(((zoom + 1) & 0b11111) == (zoom + 1)); // Zoom encoded in the lower 5 bits
+                
+                std::uint32_t id = static_cast<std::uint32_t>((i << 5) + (zoom + 1));
 
                 // find all nearby points
                 previous.tree.within(p.pos.x, p.pos.y, r, [&](const auto &neighbor_id) {

--- a/include/supercluster.hpp
+++ b/include/supercluster.hpp
@@ -243,6 +243,16 @@ private:
         }
 
         Zoom(Zoom &previous, const double r, const std::uint8_t zoom) {
+
+            // Zoom encoded in the lower 5 bits
+            bool valid_zoom = (((zoom + 1) & 0b11111) == (zoom + 1));
+#ifdef NDEBUG
+            if (!valid_zoom)
+                return;
+#else
+            assert(valid_zoom);
+#endif
+
             for (std::size_t i = 0; i < previous.clusters.size(); i++) {
                 auto &p = previous.clusters[i];
 
@@ -253,8 +263,14 @@ private:
                 auto num_points = p.num_points;
                 point<double> weight = p.pos * double(num_points);
 
-                assert((i & ((1 << 27) - 1)) == i); // point_index encoded in the upper 27 bits
-                assert(((zoom + 1) & 0b11111) == (zoom + 1)); // Zoom encoded in the lower 5 bits
+                // point_index encoded in the upper 27 bits
+                bool valid_point_index = ((i & 0x7ffffff) == i);
+#ifdef NDEBUG
+                if (!valid_point_index)
+                    return;
+#else
+                assert(valid_point_index);
+#endif
                 
                 std::uint32_t id = static_cast<std::uint32_t>((i << 5) + (zoom + 1));
 


### PR DESCRIPTION
With release `0.3.0` iOS has a compile error:

```
Implicit conversion loses integer precision: 'unsigned long' to 'std::uint32_t' (aka 'unsigned int')
```

This PR adds a `static_cast` and associated asserts/early return.

