### PR TITLE
Backport generateId from supercluster.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS += -I include --std=c++14 -Wall -Wextra -Werror -O3
+CFLAGS += -I include --std=c++14 -Wall -Wextra -Werror -Wshadow
 
 export MASON_DIR = $(shell pwd)/.mason
 export MASON = $(MASON_DIR)/mason
@@ -25,11 +25,11 @@ mason_packages: $(MASON_DIR)
 
 build/bench: bench.cpp include/* mason_packages Makefile
 	mkdir -p build
-	$(CXX) bench.cpp $(CFLAGS) $(DEPS) $(RAPIDJSON_DEP) -o build/bench
+	$(CXX) bench.cpp $(CFLAGS) -O3 $(DEPS) $(RAPIDJSON_DEP) -o build/bench
 
 build/test: test/test.cpp include/* mason_packages Makefile
 	mkdir -p build
-	$(CXX) test/test.cpp $(CFLAGS) $(DEPS) $(RAPIDJSON_DEP) -o build/test
+	$(CXX) test/test.cpp $(CFLAGS) -O0 -ggdb3 $(DEPS) $(RAPIDJSON_DEP) -o build/test
 
 run-bench: build/bench
 	./build/bench

--- a/include/supercluster.hpp
+++ b/include/supercluster.hpp
@@ -126,6 +126,7 @@ struct Options {
     std::uint16_t radius = 40;  // cluster radius in pixels
     std::uint16_t extent = 512; // tile extent (radius is calculated relative to it)
     std::size_t minPoints = 2;  // minimum points to form a cluster
+    bool generateId = false;    // whether to generate numeric ids for input features (in vector tiles)
 
     std::function<property_map(const property_map &)> map =
         [](const property_map &p) -> property_map { return p; };
@@ -187,7 +188,9 @@ public:
 
             if (c.num_points == 1) {
                 const auto &original_feature = this->features[c.id];
-                result.emplace_back(point, original_feature.properties, original_feature.id);
+                // Generate feature id if options.generateId is set.
+                auto featureId = options.generateId ? identifier{static_cast<std::uint64_t>(c.id)} : original_feature.id;
+                result.emplace_back(point, original_feature.properties, std::move(featureId));
             } else {
                 result.emplace_back(point, c.getProperties(),
                                     identifier(static_cast<std::uint64_t>(c.id)));

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -196,4 +196,18 @@ int main() {
     }
 
     assert(num_points1 == 195);
+
+    // ----------------------- test for generateId -----------------------
+    mapbox::supercluster::Options generateIdoptions;
+    generateIdoptions.generateId = true;
+    mapbox::supercluster::Supercluster generateIdIndex(features, generateIdoptions);
+    std::vector<uint64_t> ids;
+    auto generateIdfeatures = generateIdIndex.getTile(0, 0, 0);
+    for(const auto& feature : generateIdfeatures) {
+        if (feature.properties.find("cluster") == feature.properties.end()) {
+            ids.push_back(feature.id.get<uint64_t>());
+        }
+    }
+
+    assert((ids == std::vector<uint64_t>{12, 20, 21, 22, 24, 28, 30, 62, 81, 118, 119, 125, 81, 118}));
 }


### PR DESCRIPTION
This change backports generateId feature from js library. The feature allows to generate unique feature ids if `Options.generateId` is set to true.